### PR TITLE
Fix blocking funciton call

### DIFF
--- a/lib/chef/handler/copperegg.rb
+++ b/lib/chef/handler/copperegg.rb
@@ -22,7 +22,7 @@ class Chef
         if elapsed < 60                                       # force duration to be >= 1 min for annotations to display
           annot_endtime = run_status.start_time.to_i + 60
         else
-          annot_endtime = run_statusend_time.to_i
+          annot_endtime = run_status.end_time.to_i
         end
         elapsed_str = elapsed.to_s + (elapsed <= 1 ? 'second' : 'seconds')
 


### PR DESCRIPTION
CopperEgg/chef-copperegg#2

This fixes part two of the problem with teh bad call to the function
`run_statusend_time`

It also provides a work around for part one.  This file can now be dropped into
`/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-10.24.0/lib/chef/handler/copperegg.r`
and the annotations will work.
